### PR TITLE
Make key auto-repeat detection possible for engines.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ set(CPACK_SOURCE_IGNORE_FILES
     "build/"
 )
 include(CPack)
+include(CheckFunctionExists)
 
 configure_file(ibus-qt.spec.in ibus-qt.spec)
 configure_file(docs/Doxyfile.in docs/Doxyfile)
@@ -65,6 +66,12 @@ configure_file(docs/Doxyfile.in docs/Doxyfile)
 # Requires
 # check X11
 find_package(X11 REQUIRED)
+# check for XkbSetDetectableAutoRepeat
+if (X11_Xkblib_INCLUDE_PATH)
+    set(CMAKE_REQUIRED_INCLUDES "${X11_INCLUDE_DIRS}")
+    set(CMAKE_REQUIRED_LIBRARIES "${X11_LIBRARIES}")
+    check_function_exists(XkbSetDetectableAutoRepeat HAVE_XKB_SET_DETECTABLE_AUTO_REPEAT)
+endif()
 
 # check qt
 find_package(Qt4 4.5 COMPONENTS QtCore QtGui QtDBus QtXml REQUIRED)

--- a/qtim/CMakeLists.txt
+++ b/qtim/CMakeLists.txt
@@ -7,6 +7,10 @@ include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/../src
 )
 
+if (HAVE_XKB_SET_DETECTABLE_AUTO_REPEAT)
+    set(CMAKE_CXX_FLAGS -DHAVE_XKB_SET_DETECTABLE_AUTO_REPEAT)
+endif()
+
 link_directories(
     ${X11_LIBRARY_DIRS}
     ${DBUS_LIBRARY_DIRS}

--- a/qtim/ibus-input-context.cpp
+++ b/qtim/ibus-input-context.cpp
@@ -32,8 +32,7 @@
 # include <X11/Xlib.h>
 # include <X11/keysym.h>
 # include <X11/Xutil.h>
-# ifdef HAVE_X11_XKBLIB_H
-#  define HAVE_XKB
+# ifdef HAVE_XKB_SET_DETECTABLE_AUTO_REPEAT
 #  include <X11/XKBlib.h>
 # endif
 #endif
@@ -103,6 +102,13 @@ IBusInputContext::IBusInputContext (const BusPointer &bus)
     connect (m_bus, SIGNAL (disconnected (void)),
              this, SLOT (slotDisconnected (void)));
 
+#ifdef HAVE_XKB_SET_DETECTABLE_AUTO_REPEAT
+    {
+        Bool supported;
+
+        XkbSetDetectableAutoRepeat(QX11Info().display(), TRUE, &supported);
+    }
+#endif
 }
 
 IBusInputContext::~IBusInputContext (void)


### PR DESCRIPTION
If auto-repeat is enabled for a key, the sequence will normally be:

press, release, press, release... press, relase

Which means it's impossible for an engine to detect auto-repeat events
(and for example filter them out to detect when a key is really
released).

Using XkbSetDetectableAutoRepeat change the sequence to:

press, press... release

So it's now possible to filter those auto-repeat events.
