### PR TITLE
fix keycode handling

### DIFF
--- a/qtim/ibus-input-context.cpp
+++ b/qtim/ibus-input-context.cpp
@@ -274,14 +274,9 @@ translate_x_key_event (XEvent *xevent, uint *keyval, uint *keycode, uint *state)
     if (xevent->type == KeyRelease)
         *state |= IBus::ReleaseMask;
 
-    char key_str[64];
-    /* Follow gtkxim module.
-     * https://git.gnome.org/browse/gtk+/tree/modules/input/gtkimcontextxim.c#n736
-     * I think XLookupString can get right keyval even if the return value
-     * is 0 but key_str might not be a string.
-     * And XLookupString won't return the negative value in my test. */
-    XLookupString (&xevent->xkey, key_str, sizeof (key_str),
-                   (KeySym *)keyval, 0);
+    KeySym keysym = 0;
+    XLookupString (&xevent->xkey, NULL, 0, &keysym, 0);
+    *keyval = keysym;
 
     return true;
 


### PR DESCRIPTION
When building on my machine (Arch Linux 64bits):

sizeof (uint) != sizeof (KeySym)

This result in keycode being overwritten and invalid when used in
engines (it's always set to 4294967288 in my case).
